### PR TITLE
chore: Convert example `1-with-urql-client` to TypeScript

### DIFF
--- a/examples/1-with-urql-client/components/pokemon_list.tsx
+++ b/examples/1-with-urql-client/components/pokemon_list.tsx
@@ -22,7 +22,7 @@ const typesToIcon = new Map([
   ['Water', '/types/Water@2x.png'],
 ]);
 
-const queryPokemon = gql`
+const queryPokémon = gql`
   query pokemon($first: Int!) {
     pokemons(first: $first) {
       id
@@ -38,8 +38,31 @@ const queryPokemon = gql`
   }
 `;
 
-const PokemonList = () => {
-  const [result] = useQuery({ query: queryPokemon, variables: { first: 20 } });
+interface PokémonData {
+  pokemons: Pokémon[];
+}
+
+interface PokémonVariables {
+  first: number;
+}
+
+interface Pokémon {
+  id: string;
+  name: string;
+  types: string[];
+  resistant: string[];
+  weaknesses: string[];
+  image: string;
+  evolutions: {
+    name: string;
+  };
+}
+
+const PokémonList: React.FC = () => {
+  const [result] = useQuery<PokémonData, PokémonVariables>({
+    query: queryPokémon,
+    variables: { first: 20 },
+  });
 
   if (result.fetching || !result.data) {
     return null;
@@ -51,41 +74,37 @@ const PokemonList = () => {
 
   return (
     <>
-      <div className="pokemon-list">
-        {result.data.pokemons.map(pokemon => (
-          <div key={pokemon.id}>
-            <img src={pokemon.image} className="pokemon-image" />
+      <div className="pokémon-list">
+        {result.data.pokemons.map(pokémon => (
+          <div key={pokémon.id}>
+            <img src={pokémon.image} className="pokémon-image" />
             <div>
-              <h2>{pokemon.name}</h2>
-              <div className="pokemon-type-container">
-                {pokemon.types.map(type => {
-                  if (typesToIcon.get(type)) {
-                    return (
-                      <div className="pokemon-type-container__type" key={type}>
-                        <img
-                          src={typesToIcon.get(type)}
-                          className="pokemon-type-container__type-icon"
-                        />
-                        <span className="pokemon-type-container__type-text">
-                          {type}
-                        </span>
-                      </div>
-                    );
-                  }
-
-                  return null;
-                })}
+              <h2>{pokémon.name}</h2>
+              <div className="pokémon-type-container">
+                {pokémon.types
+                  .filter(type => typesToIcon.has(type))
+                  .map(type => (
+                    <div className="pokémon-type-container__type" key={type}>
+                      <img
+                        src={typesToIcon.get(type)}
+                        className="pokémon-type-container__type-icon"
+                      />
+                      <span className="pokémon-type-container__type-text">
+                        {type}
+                      </span>
+                    </div>
+                  ))}
               </div>
             </div>
           </div>
         ))}
       </div>
-      <style jsx>{`
+      <style>{`
         * {
           font-family: monospace;
         }
 
-        .pokemon-list {
+        .pokémon-list {
           display: grid;
           grid-template-columns: repeat(4, 1fr);
           grid-template-rows: repeat(5, 1fr);
@@ -93,27 +112,27 @@ const PokemonList = () => {
           padding: 1rem;
         }
 
-        .pokemon-image {
+        .pokémon-image {
           height: 15rem;
         }
 
-        .pokemon-type-container,
-        .pokemon-type-container__type {
+        .pokémon-type-container,
+        .pokémon-type-container__type {
           display: flex;
         }
 
-        .pokemon-type-container__type {
+        .pokémon-type-container__type {
           margin-right: 0.5rem;
         }
 
-        .pokemon-type-container__type-text {
+        .pokémon-type-container__type-text {
           background: #f1f8ff;
           color: #0366d6;
           padding: 0.5rem;
           border-radius: 0.5rem;
         }
 
-        .pokemon-type-container__type-icon {
+        .pokémon-type-container__type-icon {
           height: 2rem;
         }
       `}</style>
@@ -121,4 +140,4 @@ const PokemonList = () => {
   );
 };
 
-export default PokemonList;
+export default PokémonList;

--- a/examples/1-with-urql-client/next-env.d.ts
+++ b/examples/1-with-urql-client/next-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />

--- a/examples/1-with-urql-client/pages/index.tsx
+++ b/examples/1-with-urql-client/pages/index.tsx
@@ -1,26 +1,27 @@
 import React from 'react';
 import Head from 'next/head';
+import { NextPageContext } from 'next';
 import { withUrqlClient } from 'next-urql';
 
-import PokemonList from '../components/pokemon_list';
+import PokémonList from '../components/pokemon_list';
 
-const Home = () => (
+const Home: React.FC = () => (
   <div>
     <Head>
       <title>Home</title>
       <link rel="icon" href="/static/favicon.ico" />
     </Head>
 
-    <PokemonList />
+    <PokémonList />
   </div>
 );
 
-export default withUrqlClient(ctx => {
+export default withUrqlClient((ctx: NextPageContext) => {
   return {
     url: 'https://graphql-pokemon.now.sh',
     fetchOptions: {
       headers: {
-        Authorization: `Bearer ${ctx.req.token}`,
+        Authorization: `Bearer ${ctx.req.headers.authorization}`,
       },
     },
   };

--- a/examples/1-with-urql-client/pages/index.tsx
+++ b/examples/1-with-urql-client/pages/index.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import Head from 'next/head';
-import { withUrqlClient } from 'next-urql';
-
-import { NextContext } from '../../../node_modules/@types/next/index';
+import { withUrqlClient, NextContextWithAppTree } from 'next-urql';
 import PokémonList from '../components/pokemon_list';
 
 const Home: React.FC = () => (
@@ -16,7 +14,7 @@ const Home: React.FC = () => (
   </div>
 );
 
-export default withUrqlClient((ctx: NextContext) => {
+export default withUrqlClient((ctx: NextContextWithAppTree) => {
   return {
     url: 'https://graphql-pokemon.now.sh',
     fetchOptions: {

--- a/examples/1-with-urql-client/pages/index.tsx
+++ b/examples/1-with-urql-client/pages/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import Head from 'next/head';
-import { NextPageContext } from 'next';
 import { withUrqlClient } from 'next-urql';
 
+import { NextContext } from '../../../node_modules/@types/next/index';
 import PokémonList from '../components/pokemon_list';
 
 const Home: React.FC = () => (
@@ -16,7 +16,7 @@ const Home: React.FC = () => (
   </div>
 );
 
-export default withUrqlClient((ctx: NextPageContext) => {
+export default withUrqlClient((ctx: NextContext) => {
   return {
     url: 'https://graphql-pokemon.now.sh',
     fetchOptions: {

--- a/examples/1-with-urql-client/tsconfig.json
+++ b/examples/1-with-urql-client/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "exclude": [
+    "node_modules"
+  ],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ]
+}

--- a/examples/1-with-urql-client/tsconfig.json
+++ b/examples/1-with-urql-client/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "next-urql": ["../../"]
+    },
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -18,12 +18,6 @@
     "isolatedModules": true,
     "jsx": "preserve"
   },
-  "exclude": [
-    "node_modules"
-  ],
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx"
-  ]
+  "exclude": ["node_modules"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]
 }


### PR DESCRIPTION
### Summary

This PR converts `1-with-urql-client` to use TypeScript. I wanted to get feedback on this before converting the second example 😄

It was fairly straightforward, but I ran into somewhat of a version mismatch issue. In Next 9, [`NextContext`](https://github.com/FormidableLabs/next-urql/blob/master/src/with-urql-client.tsx#L2) became [`NextPageContext`](https://github.com/zeit/next.js/blob/canary/packages/next/types/index.d.ts#L56). `next-urql` uses types from Next 8, while this example is on Next 9. Unless there are backward compatibility issues, I think we should upgrade `next-urql` to Next 9; for the time being, my solution is to [import `NextContext` from `next-urql`'s `node_modules`](https://github.com/FormidableLabs/next-urql/compare/update-examples-to-typescript?expand=1#diff-d531fd807719c2b4b12c963d838b4251R5):

```js
import { NextContext } from '../../../node_modules/@types/next/index';
```

**NOTES:**
1. In order to avoid adding `next-urql` as a local dependency, we [point the TS compiler to where it can find `next-urql` in `tsconfig.json`](https://github.com/FormidableLabs/next-urql/compare/update-examples-to-typescript?expand=1#diff-1a3b4bafc0399ab1dda3bf03ad7edf99R3-R6):

```
{
  "compilerOptions": {
    "baseUrl": ".",
    "paths": {
      "next-urql": ["../../"]
    },
    ...
}
```

2. I converted variables named pokemon to pokémon bc we can 😄