### PR TITLE
Remove serialization of clientOptions in getInitialProps.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,11 +36,6 @@ jobs:
         - yarn check:format
     - <<: *checkFormatting
       node_js: 12
-    - &test
-      stage: Test
-      script:
-    - <<: *test
-      node_js: 12
     - &build
       stage: Build
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,26 +10,40 @@ branches:
 language: node_js
 
 node_js:
-  - '10'
-  - '12'
+  - 10
+  - 12
 
 install:
   - yarn install --frozen-lockfile --non-interactive
 
 jobs:
   include:
-    - stage: Check TypeScript
+    - &checkTs
+      stage: Check TypeScript
       script:
         - yarn check:types
-    - stage: Lint
+    - <<: *checkTs
+      node_js: 12
+    - &lint
+      stage: Lint
       script:
         - yarn lint
-    - stage: Check Formatting
+    - <<: *lint
+      node_js: 12
+    - &checkFormatting
+      stage: Check Formatting
       script:
         - yarn check:format
-    - stage: Test
+    - <<: *checkFormatting
+      node_js: 12
+    - &test
+      stage: Test
       script:
-        - yarn test
-    - stage: Build
+    - <<: *test
+      node_js: 12
+    - &build
+      stage: Build
       script:
         - yarn build
+    - <<: *build
+      node_js: 12

--- a/__tests__/with-urql-client.spec.tsx
+++ b/__tests__/with-urql-client.spec.tsx
@@ -25,6 +25,7 @@ describe('withUrqlClient', () => {
   });
 
   const spyInitUrqlClient = jest.spyOn(init, 'initUrqlClient');
+  const mockMergeExchanges = jest.fn(() => defaultExchanges);
   let Component: NextComponentType<any>;
 
   beforeEach(() => {
@@ -33,6 +34,7 @@ describe('withUrqlClient', () => {
 
   afterEach(() => {
     spyInitUrqlClient.mockClear();
+    mockMergeExchanges.mockClear();
   });
 
   describe('with client options', () => {
@@ -69,7 +71,7 @@ describe('withUrqlClient', () => {
   });
 
   describe('with ctx callback to create client options', () => {
-    // Simulate a token that might be passed in a request to the server-render application.
+    // Simulate a token that might be passed in a request to the server-rendered application.
     const token = Math.random()
       .toString(36)
       .slice(-10);
@@ -86,8 +88,6 @@ describe('withUrqlClient', () => {
       } as NextUrqlContext['req'],
       urqlClient: {} as Client,
     };
-
-    const mockMergeExchanges = jest.fn(() => defaultExchanges);
 
     beforeEach(() => {
       Component = withUrqlClient(
@@ -115,8 +115,6 @@ describe('withUrqlClient', () => {
   });
 
   describe('with mergeExchanges provided', () => {
-    const mockMergeExchanges = jest.fn(() => defaultExchanges);
-
     beforeEach(() => {
       Component = withUrqlClient(
         { url: 'http://localhost:3000' },

--- a/__tests__/with-urql-client.spec.tsx
+++ b/__tests__/with-urql-client.spec.tsx
@@ -20,16 +20,12 @@ const MockAppTree: React.FC = () => {
 };
 
 describe('withUrqlClient', () => {
-  beforeAll(() => {
-    configure({ adapter: new Adapter() });
-  });
-
   const spyInitUrqlClient = jest.spyOn(init, 'initUrqlClient');
   const mockMergeExchanges = jest.fn(() => defaultExchanges);
   let Component: NextComponentType<any>;
 
-  beforeEach(() => {
-    Component = withUrqlClient({ url: 'http://localhost:3000' })(MockApp);
+  beforeAll(() => {
+    configure({ adapter: new Adapter() });
   });
 
   afterEach(() => {
@@ -38,6 +34,10 @@ describe('withUrqlClient', () => {
   });
 
   describe('with client options', () => {
+    beforeEach(() => {
+      Component = withUrqlClient({ url: 'http://localhost:3000' })(MockApp);
+    });
+
     const mockContext: NextUrqlContext = {
       AppTree: MockAppTree,
       pathname: '/',

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,9 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  globals: {
+    'ts-jest': {
+      babelConfig: true,
+    },
+  },
 };

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "graphql-tag": "^2.10.1",
     "isomorphic-unfetch": "^3.0.0",
     "jest": "^24.9.0",
-    "next": "^9.1.7",
+    "next": "^9.2.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.18.2",
     "react": "^16.8.6",
@@ -66,13 +66,13 @@
     "rollup-plugin-typescript2": "^0.24.3",
     "styled-components": "^4.4.0",
     "terser": "^4.3.9",
-    "ts-jest": "^24.1.0",
+    "ts-jest": "^25.2.0",
     "tslib": "^1.10.0",
     "typescript": "^3.6.4",
     "urql": "^1.6.1"
   },
   "dependencies": {
-    "react-ssr-prepass": "^1.0.8"
+    "react-ssr-prepass": "^1.1.0"
   },
   "peerDependencies": {
     "isomorphic-unfetch": "^3.0.0",

--- a/src/init-urql-client.ts
+++ b/src/init-urql-client.ts
@@ -5,18 +5,19 @@ import {
   fetchExchange,
   ssrExchange,
   Client,
-  ClientOptions,
   Exchange,
 } from 'urql';
 import { SSRData, SSRExchange } from 'urql/dist/types/exchanges/ssr';
 
 import 'isomorphic-unfetch';
 
+import { NextUrqlClientOptions } from './with-urql-client';
+
 let urqlClient: Client | null = null;
 let ssrCache: SSRExchange | null = null;
 
 export function initUrqlClient(
-  clientOptions: ClientOptions,
+  clientOptions: NextUrqlClientOptions,
   mergeExchanges: (ssrEx: SSRExchange) => Exchange[] = ssrEx => [
     dedupExchange,
     cacheExchange,

--- a/src/with-urql-client.tsx
+++ b/src/with-urql-client.tsx
@@ -62,7 +62,7 @@ function withUrqlClient<T = any, IP = any>(
       const client = React.useMemo(() => {
         const clientOptions =
           typeof clientConfig === 'function' ? clientConfig() : clientConfig;
-
+        console.log('I get called server-side', urqlClient);
         return (
           urqlClient ||
           pageProps?.urqlClient ||
@@ -91,7 +91,6 @@ function withUrqlClient<T = any, IP = any>(
         typeof clientConfig === 'function'
           ? clientConfig(isApp ? appCtx : (ctx as NextPageContext))
           : clientConfig;
-      console.log({ opts });
       const [urqlClient, ssrCache] = initUrqlClient(opts, mergeExchanges);
 
       if (urqlClient) {

--- a/src/with-urql-client.tsx
+++ b/src/with-urql-client.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { NextPage, NextPageContext, NextComponentType } from 'next';
+import { AppContext } from 'next/app';
 import ssrPrepass from 'react-ssr-prepass';
 import {
   Provider,
@@ -14,7 +15,10 @@ import { SSRExchange, SSRData } from 'urql/dist/types/exchanges/ssr';
 
 import { initUrqlClient } from './init-urql-client';
 
-type NextUrqlClientOptions = Omit<ClientOptions, 'exchanges' | 'suspense'>;
+export type NextUrqlClientOptions = Omit<
+  ClientOptions,
+  'exchanges' | 'suspense'
+>;
 
 interface WithUrqlClient {
   urqlClient?: Client;
@@ -22,7 +26,6 @@ interface WithUrqlClient {
 
 interface WithUrqlInitialProps {
   urqlState: SSRData;
-  clientOptions: NextUrqlClientOptions;
 }
 
 interface PageProps {
@@ -35,7 +38,7 @@ export interface NextUrqlContext extends NextPageContext {
 
 type NextUrqlClientConfig =
   | NextUrqlClientOptions
-  | ((ctx: NextPageContext) => NextUrqlClientOptions);
+  | ((ctx?: NextPageContext) => NextUrqlClientOptions);
 
 function withUrqlClient<T = any, IP = any>(
   clientConfig: NextUrqlClientConfig,
@@ -51,19 +54,21 @@ function withUrqlClient<T = any, IP = any>(
       NextUrqlContext,
       IP | (IP & WithUrqlInitialProps),
       T & IP & WithUrqlClient & WithUrqlInitialProps & PageProps
-    > = ({ urqlClient, urqlState, clientOptions, pageProps, ...rest }) => {
-      /**
-       * The React Hooks ESLint plugin will not interpret withUrql as a React component
-       * due to the NextComponentType annotation. Ignore the warning about not using useMemo.
-       */
+    > = ({ urqlClient, urqlState, pageProps, ...rest }) => {
+      // The React Hooks ESLint plugin will not interpret withUrql as a React component
+      // due to the NextComponentType annotation. Ignore the warning about not using useMemo.
+
       // eslint-disable-next-line react-hooks/rules-of-hooks
-      const client = React.useMemo(
-        () =>
+      const client = React.useMemo(() => {
+        const clientOptions =
+          typeof clientConfig === 'function' ? clientConfig() : clientConfig;
+
+        return (
           urqlClient ||
-          (pageProps && pageProps.urqlClient) ||
-          initUrqlClient(clientOptions, mergeExchanges, urqlState)[0],
-        [urqlClient, pageProps, clientOptions, urqlState],
-      ) as Client;
+          pageProps?.urqlClient ||
+          initUrqlClient(clientOptions, mergeExchanges, urqlState)[0]
+        );
+      }, [urqlClient, pageProps, urqlState]) as Client;
 
       return (
         <Provider value={client}>
@@ -76,12 +81,18 @@ function withUrqlClient<T = any, IP = any>(
     const displayName = Page.displayName || Page.name || 'Component';
     withUrql.displayName = `withUrqlClient(${displayName})`;
 
-    withUrql.getInitialProps = async (ctx: NextPageContext) => {
+    withUrql.getInitialProps = async (ctx: NextPageContext | AppContext) => {
       const { AppTree } = ctx;
 
+      const appCtx = (ctx as AppContext).ctx;
+      const isApp = !!appCtx;
+
       const opts =
-        typeof clientConfig === 'function' ? clientConfig(ctx) : clientConfig;
-      const [urqlClient, ssrCache] = initUrqlClient(opts);
+        typeof clientConfig === 'function'
+          ? clientConfig(isApp ? appCtx : (ctx as NextPageContext))
+          : clientConfig;
+      console.log({ opts });
+      const [urqlClient, ssrCache] = initUrqlClient(opts, mergeExchanges);
 
       if (urqlClient) {
         (ctx as NextUrqlContext).urqlClient = urqlClient;
@@ -93,19 +104,14 @@ function withUrqlClient<T = any, IP = any>(
         pageProps = await Page.getInitialProps(ctx as NextUrqlContext);
       }
 
-      /**
-       * Check the window object to determine whether we are on the server.
-       * getInitialProps is universal, but we only want to run suspense on the server.
-       */
-      const isBrowser = typeof window !== 'undefined';
-      if (isBrowser) {
+      // Check the window object to determine whether or not we are on the server.
+      // getInitialProps runs on the server for initial render, and on the client for navigation.
+      // We only want to run the prepass step on the server.
+      if (typeof window !== 'undefined') {
         return pageProps;
       }
 
-      /**
-       * Run the prepass step on AppTree.
-       * This will run all urql queries on the server.
-       */
+      // Run the prepass step on AppTree. This will run all urql queries on the server.
       await ssrPrepass(
         <AppTree
           pageProps={{
@@ -115,13 +121,12 @@ function withUrqlClient<T = any, IP = any>(
         />,
       );
 
-      // Extract the SSR query data from urql's SSR cache.
-      const urqlState = ssrCache && ssrCache.extractData();
+      // Extract the query data from urql's SSR cache.
+      const urqlState = ssrCache?.extractData();
 
       return {
         ...pageProps,
         urqlState,
-        clientOptions: opts,
       };
     };
 

--- a/src/with-urql-client.tsx
+++ b/src/with-urql-client.tsx
@@ -62,7 +62,7 @@ function withUrqlClient<T = any, IP = any>(
       const client = React.useMemo(() => {
         const clientOptions =
           typeof clientConfig === 'function' ? clientConfig() : clientConfig;
-        console.log('I get called server-side', urqlClient);
+
         return (
           urqlClient ||
           pageProps?.urqlClient ||

--- a/yarn.lock
+++ b/yarn.lock
@@ -1654,6 +1654,17 @@ acorn@^7.1.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.0.tgz#949d36f2c292535da602283586c2477c57eb2d6c"
   integrity sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==
 
+adjust-sourcemap-loader@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/adjust-sourcemap-loader/-/adjust-sourcemap-loader-2.0.0.tgz#6471143af75ec02334b219f54bc7970c52fb29a4"
+  integrity sha512-4hFsTsn58+YjrU9qKzML2JSSDqKvN8mUGQ0nNIrfPi8hmIONT4L3uUaT6MKdMsZ9AjsU6D2xDkZxCkbQPxChrA==
+  dependencies:
+    assert "1.4.1"
+    camelcase "5.0.0"
+    loader-utils "1.2.3"
+    object-path "0.11.4"
+    regex-parser "2.2.10"
+
 airbnb-prop-types@^2.15.0:
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/airbnb-prop-types/-/airbnb-prop-types-2.15.0.tgz#5287820043af1eb469f5b0af0d6f70da6c52aaef"
@@ -1781,6 +1792,11 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+arity-n@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/arity-n/-/arity-n-1.0.4.tgz#d9e76b11733e08569c0847ae7b39b2860b30b745"
+  integrity sha1-2edrEXM+CFacCEeuezmyhgswt0U=
+
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
@@ -1874,6 +1890,13 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
 
+assert@1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
+  integrity sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=
+  dependencies:
+    util "0.10.3"
+
 assert@^1.1.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/assert/-/assert-1.5.0.tgz#55c109aaf6e0aefdb3dc4b71240c70bf574b18eb"
@@ -1886,6 +1909,11 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
+
+ast-types@0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.13.2.tgz#df39b677a911a83f3a049644fb74fdded23cea48"
+  integrity sha512-uWMHxJxtfj/1oZClOxDEV1sQ1HCDkA4MG8Gr69KKeBjEVH0R84WlejZ0y2DcwyBlpAEMltmVYkVgqfLFb2oyiA==
 
 astral-regex@^1.0.0:
   version "1.0.0"
@@ -2257,7 +2285,7 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
-browserslist@^4.6.0, browserslist@^4.6.4, browserslist@^4.8.0, browserslist@^4.8.2, browserslist@^4.8.3:
+browserslist@4.8.3, browserslist@^4.6.0, browserslist@^4.6.4, browserslist@^4.8.0, browserslist@^4.8.2, browserslist@^4.8.3:
   version "4.8.3"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.8.3.tgz#65802fcd77177c878e015f0e3189f2c4f627ba44"
   integrity sha512-iU43cMMknxG1ClEZ2MDKeonKE1CCrFVkQK2AqO2YWFmvIrx4JWrvQ4w4hQez6EpVI8rHTtqh/ruHHDHSOKxvUg==
@@ -2410,15 +2438,20 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
+camelcase@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.0.0.tgz#03295527d58bd3cd4aa75363f35b2e8d97be2f42"
+  integrity sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==
+
+camelcase@5.3.1, camelcase@^5.0.0, camelcase@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
+  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+
 camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
-
-camelcase@^5.0.0, camelcase@^5.3.1:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
-  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 camelize@^1.0.0:
   version "1.0.0"
@@ -2581,6 +2614,15 @@ cliui@^5.0.0:
     strip-ansi "^5.2.0"
     wrap-ansi "^5.1.0"
 
+clone-deep@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-4.0.1.tgz#c19fd9bdbbf85942b4fd979c84dcf7d5f07c2387"
+  integrity sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==
+  dependencies:
+    is-plain-object "^2.0.4"
+    kind-of "^6.0.2"
+    shallow-clone "^3.0.0"
+
 clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
@@ -2644,6 +2686,13 @@ component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
+
+compose-function@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/compose-function/-/compose-function-3.0.3.tgz#9ed675f13cc54501d30950a486ff6a7ba3ab185f"
+  integrity sha1-ntZ18TzFRQHTCVCkhv9qe6OrGF8=
+  dependencies:
+    arity-n "^1.0.4"
 
 compressible@~2.0.16:
   version "2.0.18"
@@ -2714,6 +2763,11 @@ convert-source-map@1.7.0, convert-source-map@^1.4.0, convert-source-map@^1.7.0:
   integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
   dependencies:
     safe-buffer "~5.1.1"
+
+convert-source-map@^0.3.3:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-0.3.5.tgz#f1d802950af7dd2631a1febe0596550c86ab3190"
+  integrity sha1-8dgClQr33SYxof6+BZZVDIarMZA=
 
 cookie@0.4.0:
   version "0.4.0"
@@ -2893,7 +2947,7 @@ css-what@2.1:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
   integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
 
-css@2.2.4:
+css@2.2.4, css@^2.0.0:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
   integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
@@ -2954,6 +3008,14 @@ cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
+
+d@1, d@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a"
+  integrity sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==
+  dependencies:
+    es5-ext "^0.10.50"
+    type "^1.0.1"
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -3382,6 +3444,32 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
+es5-ext@^0.10.35, es5-ext@^0.10.50:
+  version "0.10.53"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.53.tgz#93c5a3acfdbef275220ad72644ad02ee18368de1"
+  integrity sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==
+  dependencies:
+    es6-iterator "~2.0.3"
+    es6-symbol "~3.1.3"
+    next-tick "~1.0.0"
+
+es6-iterator@2.0.3, es6-iterator@~2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
+  integrity sha1-p96IkUGgWpSwhUQDstCg+/qY87c=
+  dependencies:
+    d "1"
+    es5-ext "^0.10.35"
+    es6-symbol "^3.1.1"
+
+es6-symbol@^3.1.1, es6-symbol@~3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.3.tgz#bad5d3c1bcdac28269f4cb331e431c78ac705d18"
+  integrity sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==
+  dependencies:
+    d "^1.0.1"
+    ext "^1.1.2"
+
 escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
@@ -3529,7 +3617,7 @@ esprima@^3.1.3:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
   integrity sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=
 
-esprima@^4.0.0:
+esprima@^4.0.0, esprima@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
@@ -3633,6 +3721,13 @@ expect@^24.9.0:
     jest-matcher-utils "^24.9.0"
     jest-message-util "^24.9.0"
     jest-regex-util "^24.9.0"
+
+ext@^1.1.2:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/ext/-/ext-1.4.0.tgz#89ae7a07158f79d35517882904324077e4379244"
+  integrity sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==
+  dependencies:
+    type "^2.0.0"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -5736,13 +5831,6 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-native-url@0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/native-url/-/native-url-0.2.4.tgz#37623b3db2c7bb6670e50e379634248ba5ca9d90"
-  integrity sha512-McE+8BrgMw2ANypdYX9s1L+aUkbWDCEtsBGIbs8TfKBfQrFcZ2jMXX9LxGjOIOtoRXkwLTSlz38XHm8J3U6hgQ==
-  dependencies:
-    querystring "^0.2.0"
-
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -5769,10 +5857,15 @@ neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
-next@^9.1.7:
-  version "9.1.7"
-  resolved "https://registry.yarnpkg.com/next/-/next-9.1.7.tgz#d813ab3a21a98aac3713f6c1934a8533b6162eb0"
-  integrity sha512-qG6TsPl7ANuNPFhKq/1Pd4pAf24QCmUAjc0P8qYrSSsbwNIco1KNNXOyZajV/YlqBjBy/fCrZoErKK3zEUVz6w==
+next-tick@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
+  integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
+
+next@^9.2.1:
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/next/-/next-9.2.1.tgz#5275adfdeffc85b4a4b113466581a326390940c5"
+  integrity sha512-oI68lEmBLf9Z/R81wRFbziD9v/2quPdC3nRP+dTgOYcCR9F3ylbnB+D2BKYqBCLaGNXKQDt4FuVtZLYBAea6Gw==
   dependencies:
     "@ampproject/toolbox-optimizer" "1.1.1"
     "@babel/core" "7.7.2"
@@ -5798,6 +5891,7 @@ next@^9.1.7:
     babel-plugin-syntax-jsx "6.18.0"
     babel-plugin-transform-define "2.0.0"
     babel-plugin-transform-react-remove-prop-types "0.4.24"
+    browserslist "4.8.3"
     cache-loader "4.1.0"
     chalk "2.4.2"
     ci-info "2.0.0"
@@ -5825,7 +5919,6 @@ next@^9.1.7:
     lru-cache "5.1.1"
     mini-css-extract-plugin "0.8.0"
     mkdirp "0.5.1"
-    native-url "0.2.4"
     node-fetch "2.6.0"
     object-assign "4.1.1"
     ora "3.4.0"
@@ -5839,6 +5932,9 @@ next@^9.1.7:
     raw-body "2.4.0"
     react-error-overlay "5.1.6"
     react-is "16.8.6"
+    recast "0.18.5"
+    resolve-url-loader "3.1.1"
+    sass-loader "8.0.2"
     send "0.17.1"
     source-map "0.6.1"
     string-hash "1.1.3"
@@ -6034,6 +6130,11 @@ object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
+
+object-path@0.11.4:
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.11.4.tgz#370ae752fbf37de3ea70a861c23bba8915691949"
+  integrity sha1-NwrnUvvzfePqcKhhwju6iRVpGUk=
 
 object-visit@^1.0.0:
   version "1.0.1"
@@ -6844,6 +6945,15 @@ postcss-values-parser@^2.0.0, postcss-values-parser@^2.0.1:
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
+postcss@7.0.21:
+  version "7.0.21"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.21.tgz#06bb07824c19c2021c5d056d5b10c35b989f7e17"
+  integrity sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==
+  dependencies:
+    chalk "^2.4.2"
+    source-map "^0.6.1"
+    supports-color "^6.1.0"
+
 postcss@^7.0.0, postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.17, postcss@^7.0.18, postcss@^7.0.2, postcss@^7.0.23, postcss@^7.0.5, postcss@^7.0.6:
   version "7.0.26"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.26.tgz#5ed615cfcab35ba9bbb82414a4fa88ea10429587"
@@ -6885,7 +6995,7 @@ pretty-format@^24.9.0:
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
 
-private@^0.1.6:
+private@^0.1.6, private@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
   integrity sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==
@@ -7103,12 +7213,12 @@ react-is@^16.10.2, react-is@^16.12.0, react-is@^16.6.0, react-is@^16.8.1, react-
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
 
-react-ssr-prepass@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/react-ssr-prepass/-/react-ssr-prepass-1.0.8.tgz#036abffe541975b20213cf7b261c05ac2843480d"
-  integrity sha512-O0gfRA1SaK+9ITKxqfnXsej2jF+OHGP/+GxD4unROQaM/0/UczGF9fuF+wTboxaQoKdIf4FvS3h/OigWh704VA==
+react-ssr-prepass@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-ssr-prepass/-/react-ssr-prepass-1.1.0.tgz#f765378009423181ca7b6d59ca71f7af1073a3a4"
+  integrity sha512-FKoL5+YJxkNDhcTFfBgWM82PPHS4AC+uc05ja//CR3+xHPQ6i9UfWyHx8vakIIaBzsHeaRtRhOO8uHhn1R8Dnw==
   dependencies:
-    object-is "^1.0.1"
+    object-is "^1.0.2"
 
 react-test-renderer@^16.0.0-0:
   version "16.12.0"
@@ -7205,6 +7315,16 @@ realpath-native@^1.1.0:
   dependencies:
     util.promisify "^1.0.0"
 
+recast@0.18.5:
+  version "0.18.5"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.18.5.tgz#9d5adbc07983a3c8145f3034812374a493e0fe4d"
+  integrity sha512-sD1WJrpLQAkXGyQZyGzTM75WJvyAd98II5CHdK3IYbt/cZlU0UzCRVU11nUFNXX9fBVEt4E9ajkMjBlUlG+Oog==
+  dependencies:
+    ast-types "0.13.2"
+    esprima "~4.0.0"
+    private "^0.1.8"
+    source-map "~0.6.1"
+
 reflect.ownkeys@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz#749aceec7f3fdf8b63f927a04809e90c5c0b3460"
@@ -7246,6 +7366,11 @@ regex-not@^1.0.0, regex-not@^1.0.2:
   dependencies:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
+
+regex-parser@2.2.10:
+  version "2.2.10"
+  resolved "https://registry.yarnpkg.com/regex-parser/-/regex-parser-2.2.10.tgz#9e66a8f73d89a107616e63b39d4deddfee912b37"
+  integrity sha512-8t6074A68gHfU8Neftl0Le6KTDwfGAj7IyjPIMSfikI2wJUTHDMaIq42bUsfVnj8mhx0R+45rdUXHGpN164avA==
 
 regexpp@^2.0.1:
   version "2.0.1"
@@ -7365,6 +7490,22 @@ resolve-from@^4.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
+resolve-url-loader@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/resolve-url-loader/-/resolve-url-loader-3.1.1.tgz#28931895fa1eab9be0647d3b2958c100ae3c0bf0"
+  integrity sha512-K1N5xUjj7v0l2j/3Sgs5b8CjrrgtC70SmdCuZiJ8tSyb5J+uk3FoeZ4b7yTnH6j7ngI+Bc5bldHJIa8hYdu2gQ==
+  dependencies:
+    adjust-sourcemap-loader "2.0.0"
+    camelcase "5.3.1"
+    compose-function "3.0.3"
+    convert-source-map "1.7.0"
+    es6-iterator "2.0.3"
+    loader-utils "1.2.3"
+    postcss "7.0.21"
+    rework "1.0.1"
+    rework-visit "1.0.0"
+    source-map "0.6.1"
+
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
@@ -7421,6 +7562,19 @@ retry@0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
   integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
+
+rework-visit@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/rework-visit/-/rework-visit-1.0.0.tgz#9945b2803f219e2f7aca00adb8bc9f640f842c9a"
+  integrity sha1-mUWygD8hni96ygCtuLyfZA+ELJo=
+
+rework@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/rework/-/rework-1.0.1.tgz#30806a841342b54510aa4110850cd48534144aa7"
+  integrity sha1-MIBqhBNCtUUQqkEQhQzUhTQUSqc=
+  dependencies:
+    convert-source-map "^0.3.3"
+    css "^2.0.0"
 
 rimraf@2.6.3:
   version "2.6.3"
@@ -7575,6 +7729,17 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
+sass-loader@8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-8.0.2.tgz#debecd8c3ce243c76454f2e8290482150380090d"
+  integrity sha512-7o4dbSK8/Ol2KflEmSco4jTjQoV988bM82P9CZdmo9hR3RLnvNc0ufMNdMrB0caq38JQ/FgF4/7RcbcfKzxoFQ==
+  dependencies:
+    clone-deep "^4.0.1"
+    loader-utils "^1.2.3"
+    neo-async "^2.6.1"
+    schema-utils "^2.6.1"
+    semver "^6.3.0"
+
 sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
@@ -7601,6 +7766,14 @@ schema-utils@^2.0.0, schema-utils@^2.0.1, schema-utils@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.6.1.tgz#eb78f0b945c7bcfa2082b3565e8db3548011dc4f"
   integrity sha512-0WXHDs1VDJyo+Zqs9TKLKyD/h7yDpHUhEFsM2CzkICFdoX1av+GBq/J2xRTFfsQO5kBfhZzANf2VcIm84jqDbg==
+  dependencies:
+    ajv "^6.10.2"
+    ajv-keywords "^3.4.1"
+
+schema-utils@^2.6.1:
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.6.4.tgz#a27efbf6e4e78689d91872ee3ccfa57d7bdd0f53"
+  integrity sha512-VNjcaUxVnEeun6B2fiiUDjXXBtD4ZSH7pdbfIu1pOFwgptDPLMo/z9jr4sUfsjFVPqDCEin/F7IYlq7/E6yDbQ==
   dependencies:
     ajv "^6.10.2"
     ajv-keywords "^3.4.1"
@@ -7676,6 +7849,13 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+shallow-clone@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-3.0.1.tgz#8f2981ad92531f55035b01fb230769a40e02efa3"
+  integrity sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==
+  dependencies:
+    kind-of "^6.0.2"
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -8314,10 +8494,10 @@ traverse@0.6.6:
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
   integrity sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=
 
-ts-jest@^24.1.0:
-  version "24.3.0"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-24.3.0.tgz#b97814e3eab359ea840a1ac112deae68aa440869"
-  integrity sha512-Hb94C/+QRIgjVZlJyiWwouYUF+siNJHJHknyspaOcZ+OQAIdFG/UrdQVXw/0B8Z3No34xkUXZJpOTy9alOWdVQ==
+ts-jest@^25.2.0:
+  version "25.2.0"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-25.2.0.tgz#dfd87c2b71ef4867f5a0a44f40cb9c67e02991ac"
+  integrity sha512-VaRdb0da46eorLfuHEFf0G3d+jeREcV+Wb/SvW71S4y9Oe8SHWU+m1WY/3RaMknrBsnvmVH0/rRjT8dkgeffNQ==
   dependencies:
     bs-logger "0.x"
     buffer-from "1.x"
@@ -8375,6 +8555,16 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+type@^1.0.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/type/-/type-1.2.0.tgz#848dd7698dafa3e54a6c479e759c4bc3f18847a0"
+  integrity sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==
+
+type@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/type/-/type-2.0.0.tgz#5f16ff6ef2eb44f260494dae271033b29c09a9c3"
+  integrity sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"


### PR DESCRIPTION
This PR begins to address #16.

### The Problem

As @kitten and @JoviDeCroock have pointed out, serializing `clientOptions` in `getInitialProps` is problematic in the case where a user **wants to use a different `urql` Client configuration on the client and the server**. This is a safe assumption to make – users may need to query different APIs in these two environments or have a different set of `fetchOptions`. We still want to populate the client-side cache with the server-side query results, but we _don't_ want to lock users in to one and only one Client configuration for the lifetime of their app. Their initial server render may need one thing and their subsequent client-side render may need another.

### The Solution

To fix this problem, we do the following:

- Remove returning `clientOptions` in `getInitialProps`.
- Create the Client instance on the client-side inside of `useMemo` in the `withUrql` component.

### How This All Works

1. Initial server render occurs. `getInitialProps` is called and `initUrqlClient` is called. We can safely access `ctx` and the `Client` is created 🎉 
2. `withUrql` renders on the server. The `useMemo` in `withUrql` gets called, and `initUrqlClient` is called again. We _cannot_ safely access `ctx` here, since it can't be returned in `getInitialProps`. Call to `initUrqlClient` is made, which clobbers the previous instance created in `getInitialProps`. In some ways this doesn't matter because the important part is preserved – we have our SSR cache.
3. HTML markup is sent to the client-side, along with the SSR cache. `withUrql` renders on the client-side and the `urql` Client instance for the client-side is created and rehydrated with the SSR cache. Again, we _cannot_ safely access `ctx` on this first client-side render.

This all feels expected to me, although we will want to signal to users that `ctx`'s presence is now quite fickle (the types reflect this).

### Remaining Questions

This will ergonomically fix the case where you want a different server and client configuration for your `urql` Client instance. It **will not**, however, fix the case where you want to _update_ your `urql` Client instance during client-side navigation (i.e add a new `fetchOption`), which was the original ask of #16. This line: https://github.com/FormidableLabs/next-urql/blob/master/src/init-urql-client.ts#L34 is the key reason why – after that first render client-side, we have an `urqlClient` already in scope, so the code to change it will never run.

To actually _update_ the `Client` instance on the client-side, I think we'd need to introduce a separate flag, something like `updateOnNavigation`. If `true`, this would create a new client every time you navigated to a page wrapped by `withUrqlClient`, guaranteeing you always got the latest `fetchOptions` you set. This seems dubious, and I think @ryan-gilb's exchanges example shows a more ergonomic way to accomplish this – using exchanges to alter a url for a particular route or supply an auth token once it's actually been retrieved.

### For Reviewers

Does this all make sense to you? Does this feel like a reasonable trade-off to make? My goal is that this, alongside Ryan's example, can put #16 to bed. The idea of a Client instance that changes per page sounds difficult to reasonably manage in this lib – for those who really want it, a custom exchange or forking this lib seem like the best ways to go forward. Most folks, I assume, will have the same Client config across the application and, with this change, can also safely differentiate their Client config between server-side and client-side.