### PR TITLE
Add better support for _app.js. Move types to separate module.

### DIFF
--- a/__tests__/with-urql-client.spec.tsx
+++ b/__tests__/with-urql-client.spec.tsx
@@ -1,28 +1,23 @@
 import React from 'react';
 import { shallow, configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
-import { NextComponentType } from 'next';
 import { Client, defaultExchanges, composeExchanges } from 'urql';
 
-import withUrqlClient, { NextUrqlContext } from '../src/with-urql-client';
+import { withUrqlClient, NextUrqlPageContext } from '../src';
 import * as init from '../src/init-urql-client';
 
-interface Props {
-  urqlClient: Client;
-}
-
-const MockApp: React.FC<Props> = () => {
+const MockApp: React.FC<any> = () => {
   return <div />;
 };
 
-const MockAppTree: React.FC = () => {
+const MockAppTree: React.FC<any> = () => {
   return <div />;
 };
 
 describe('withUrqlClient', () => {
   const spyInitUrqlClient = jest.spyOn(init, 'initUrqlClient');
   const mockMergeExchanges = jest.fn(() => defaultExchanges);
-  let Component: NextComponentType<any>;
+  let Component: any;
 
   beforeAll(() => {
     configure({ adapter: new Adapter() });
@@ -38,7 +33,7 @@ describe('withUrqlClient', () => {
       Component = withUrqlClient({ url: 'http://localhost:3000' })(MockApp);
     });
 
-    const mockContext: NextUrqlContext = {
+    const mockContext: NextUrqlPageContext = {
       AppTree: MockAppTree,
       pathname: '/',
       query: {},
@@ -76,7 +71,7 @@ describe('withUrqlClient', () => {
       .toString(36)
       .slice(-10);
 
-    const mockContext: NextUrqlContext = {
+    const mockContext: NextUrqlPageContext = {
       AppTree: MockAppTree,
       pathname: '/',
       query: {},
@@ -85,7 +80,7 @@ describe('withUrqlClient', () => {
         headers: {
           cookie: token,
         },
-      } as NextUrqlContext['req'],
+      } as NextUrqlPageContext['req'],
       urqlClient: {} as Client,
     };
 

--- a/examples/1-with-urql-client/pages/index.tsx
+++ b/examples/1-with-urql-client/pages/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { NextPageContext, NextComponentType } from 'next';
+import { NextComponentType } from 'next';
 import Head from 'next/head';
 import { withUrqlClient, NextUrqlPageContext } from 'next-urql';
 import PokémonList from '../components/pokemon_list';
@@ -34,8 +34,7 @@ export default withUrqlClient((ctx: NextUrqlPageContext) => {
     url: 'https://graphql-pokemon.now.sh',
     fetchOptions: {
       headers: {
-        Authorization: `Bearer ${(ctx as NextPageContext)?.req?.headers
-          ?.authorization ?? ''}`,
+        Authorization: `Bearer ${ctx?.req?.headers?.authorization ?? ''}`,
       },
     },
   };

--- a/examples/1-with-urql-client/pages/index.tsx
+++ b/examples/1-with-urql-client/pages/index.tsx
@@ -1,25 +1,41 @@
 import React from 'react';
+import { NextPageContext, NextComponentType } from 'next';
 import Head from 'next/head';
-import { withUrqlClient, NextUrqlContext } from 'next-urql';
+import { withUrqlClient, NextUrqlPageContext } from 'next-urql';
 import PokémonList from '../components/pokemon_list';
 
-const Home: React.FC = () => (
+interface InitialProps {
+  title: string;
+}
+
+const Home: NextComponentType<
+  NextUrqlPageContext,
+  InitialProps,
+  InitialProps
+> = ({ title }) => (
   <div>
     <Head>
       <title>Home</title>
       <link rel="icon" href="/static/favicon.ico" />
     </Head>
-
+    <h1>{title}</h1>
     <PokémonList />
   </div>
 );
 
-export default withUrqlClient((ctx: NextUrqlContext) => {
+Home.getInitialProps = () => {
+  return {
+    title: 'Pokédex',
+  };
+};
+
+export default withUrqlClient((ctx: NextUrqlPageContext) => {
   return {
     url: 'https://graphql-pokemon.now.sh',
     fetchOptions: {
       headers: {
-        Authorization: `Bearer ${ctx.req.headers.authorization}`,
+        Authorization: `Bearer ${(ctx as NextPageContext)?.req?.headers
+          ?.authorization ?? ''}`,
       },
     },
   };

--- a/examples/2-with-_app.js/pages/_app.tsx
+++ b/examples/2-with-_app.js/pages/_app.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { withUrqlClient } from 'next-urql';
-import { AppPropsType } from 'next/dist/next-server/lib/utils';
+import { AppProps } from 'next/app';
 
-const App: React.FC<AppPropsType> = ({ Component, pageProps }) => (
-  <Component {...pageProps} />
-);
+const App = ({ Component, pageProps }: AppProps) => {
+  return <Component {...pageProps} />;
+};
 
 export default withUrqlClient({ url: 'https://graphql-pokemon.now.sh' })(App);

--- a/examples/2-with-_app.js/pages/index.tsx
+++ b/examples/2-with-_app.js/pages/index.tsx
@@ -1,17 +1,30 @@
 import React from 'react';
+import { NextPage } from 'next';
 import Head from 'next/head';
 
 import PokémonList from '../components/pokemon_list';
 
-const Home: React.FC = () => (
-  <div>
-    <Head>
-      <title>Home</title>
-      <link rel="icon" href="/favicon.ico" />
-    </Head>
+interface InitialProps {
+  title: string;
+}
 
-    <PokémonList />
-  </div>
-);
+const Home: NextPage<InitialProps> = ({ title }) => {
+  return (
+    <div>
+      <Head>
+        <title>Home</title>
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+      <h1>{title}</h1>
+      <PokémonList />
+    </div>
+  );
+};
+
+Home.getInitialProps = () => {
+  return {
+    title: 'Pokédex',
+  };
+};
 
 export default Home;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
-export { default as withUrqlClient, NextUrqlContext } from './with-urql-client';
+export { withUrqlClient } from './with-urql-client';
+export * from './types';

--- a/src/init-urql-client.ts
+++ b/src/init-urql-client.ts
@@ -8,10 +8,9 @@ import {
   Exchange,
 } from 'urql';
 import { SSRData, SSRExchange } from 'urql/dist/types/exchanges/ssr';
-
 import 'isomorphic-unfetch';
 
-import { NextUrqlClientOptions } from './with-urql-client';
+import { NextUrqlClientOptions } from './types';
 
 let urqlClient: Client | null = null;
 let ssrCache: SSRExchange | null = null;
@@ -26,11 +25,9 @@ export function initUrqlClient(
   ],
   initialState?: SSRData,
 ): [Client | null, SSRExchange | null] {
-  /**
-   * Create a new Client for every server-side rendered request.
-   * This ensures we reset the state for each rendered page.
-   * If there is an exising client instance on the client-side, use it.
-   */
+  // Create a new Client for every server-side rendered request.
+  // This ensures we reset the state for each rendered page.
+  // If there is an exising client instance on the client-side, use it.
   const isServer = typeof window === 'undefined';
   if (isServer || !urqlClient) {
     ssrCache = ssrExchange({ initialState });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,37 @@
+import { NextPageContext } from 'next';
+import { ClientOptions, Exchange, Client } from 'urql';
+import { SSRExchange, SSRData } from 'urql/dist/types/exchanges/ssr';
+import { AppContext } from 'next/app';
+
+export type NextUrqlClientOptions = Omit<
+  ClientOptions,
+  'exchanges' | 'suspense'
+>;
+
+export type NextUrqlClientConfig =
+  | NextUrqlClientOptions
+  | ((ctx?: NextPageContext) => NextUrqlClientOptions);
+
+export type MergeExchanges = (ssrExchange: SSRExchange) => Exchange[];
+
+export interface NextUrqlPageContext extends NextPageContext {
+  urqlClient: Client;
+}
+
+export interface NextUrqlAppContext extends AppContext {
+  urqlClient: Client;
+}
+
+export type NextUrqlContext = NextUrqlPageContext | NextUrqlAppContext;
+
+export interface WithUrqlState {
+  urqlState?: SSRData;
+}
+
+export interface WithUrqlClient {
+  urqlClient: Client;
+}
+
+export interface WithUrqlProps extends WithUrqlClient, WithUrqlState {
+  [key: string]: any;
+}


### PR DESCRIPTION
Fix #36 

This PR does a few things, most importantly fixing how `next-urql` returns `pageProps` when wrapping an `_app.js` component. We weren't handling this properly previously when running the prepass step. `_app.js` has a special props signature.

```jsx
const App = ({ Component, pageProps }) =>
```

in contrast to a regular Page component, which just consumes its props directly. The extra `pageProps` layer is something we needed to take into account in our HoC. Moreover, we also need to ensure we use the proper `ctx` signature for `_app.js` vs. Page components, as these structures differ as well. This PR adds an `isApp` check inside `getInitialProps` such that we attach `urqlClient` to the correct `ctx` object.

In order to make a lot of this work, I loosened the types a bit by moving away from our generics. This is fine, since the HoC doesn't really care about any props coming in from the outside (it just forwards them along), and users can just specify their component's prop types in userland.

Finally, I moved our types into a separate `./types` module to make them easier to read ✅ 