### PR TITLE
Demonstrate usage of getInitialProps in _app.js.

### DIFF
--- a/examples/2-with-_app.js/pages/_app.tsx
+++ b/examples/2-with-_app.js/pages/_app.tsx
@@ -1,9 +1,21 @@
 import React from 'react';
-import { withUrqlClient } from 'next-urql';
-import { AppProps } from 'next/app';
+import { withUrqlClient, NextUrqlAppContext } from 'next-urql';
+import NextApp, { AppProps } from 'next/app';
 
 const App = ({ Component, pageProps }: AppProps) => {
   return <Component {...pageProps} />;
 };
 
+// Implement getInitialProps if your Page components call getInitialProps themselves.
+// https://nextjs.org/docs/advanced-features/custom-app
+App.getInitialProps = async (ctx: NextUrqlAppContext) => {
+  const appProps = await NextApp.getInitialProps(ctx);
+
+  return {
+    ...appProps,
+  };
+};
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
 export default withUrqlClient({ url: 'https://graphql-pokemon.now.sh' })(App);


### PR DESCRIPTION
A smol boi demonstrating usage of `getInitialProps` on an `_app.js` component with `next-urql`. This is to clear up some questions on #35.

While al `urql` queries will get picked up and run by `react-ssr-prepass` on the initial server render, there is a trick if you have blocking data requirements in a Page component that implements `getInitialProps` _and_ is wrapped by `_app.js`. Basically, to ensure that Page's `getInitialProps` is ran, you have to call `NextApp.getInitialProps`: https://nextjs.org/docs/advanced-features/custom-app

We do have this in our second example, with the `Home` component having its own `getInitialProps` method. In order to have this function run, we need to add in this call to `NextApp.getInitialProps`.

cc/ @jgoux does this help? Your `urql` queries should still run fine in v0.3.0 if you're using `useQuery` or the `Query` component. This only applies if you're implementing `getInitialProps` in your Page components.